### PR TITLE
chore: Update Material UI to v6 with DateTimePicker migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "todo",
       "version": "0.1.0",
       "dependencies": {
-        "@emotion/react": "^11.7.0",
-        "@emotion/styled": "^11.6.0",
-        "@mui/icons-material": "^5.2.1",
-        "@mui/lab": "^5.0.0-alpha.59",
-        "@mui/material": "^5.2.3",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^6.3.0",
+        "@mui/material": "^6.3.0",
+        "@mui/x-date-pickers": "^7.23.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
-        "date-fns": "^2.27.0",
+        "date-fns": "^4.1.0",
         "firebase": "^9.0.0",
         "framer-motion": "^4.1.3",
         "react": "^18.3.1",
@@ -3139,44 +3139,6 @@
       "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw==",
       "license": "Apache-2.0"
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
@@ -3716,43 +3678,10 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.40-1",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40-1.tgz",
-      "integrity": "sha512-agKXuNNy0bHUmeU7pNmoZwNFr7Hiyhojkb9+2PVyDG5+6RafYuyMgbrav8CndsB7KUc/U51JAw9vKNDLYBzaUA==",
-      "deprecated": "This package has been replaced by @base-ui/react",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
-      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
+      "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3760,22 +3689,22 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
-      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.5.0.tgz",
+      "integrity": "sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9"
+        "@babel/runtime": "^7.26.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^5.0.0",
+        "@mui/material": "^6.5.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3785,22 +3714,27 @@
         }
       }
     },
-    "node_modules/@mui/lab": {
-      "version": "5.0.0-alpha.177",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.177.tgz",
-      "integrity": "sha512-bdCxxtNjlWAgN9rtrwlmFydJ1qxA3IIbb6OlomGFsIXw0zGoHomLyjvh72q/R3yUAC0kvSef18cHY1UalLylyQ==",
+    "node_modules/@mui/material": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
+      "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.40-1",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.5.0",
+        "@mui/system": "^6.5.0",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3809,7 +3743,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material": ">=5.15.0",
+        "@mui/material-pigment-css": "^6.5.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3821,32 +3755,92 @@
         "@emotion/styled": {
           "optional": true
         },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }
       }
     },
-    "node_modules/@mui/material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
-      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+    "node_modules/@mui/material/node_modules/@mui/private-theming": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.18.0",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
-        "react-transition-group": "^4.4.5"
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.4.9",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/styled-engine": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
+      "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/system": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
+      "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.4.9",
+        "@mui/styled-engine": "^6.5.0",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3856,8 +3850,7 @@
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -3872,17 +3865,67 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
-      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.7.tgz",
+      "integrity": "sha512-w7r1+CYhG0syCAQUWAuV5zSaU2/67WA9JXUderdb7DzCIJdp/5RmJv6L85wRjgKCMsxFF0Kfn0kPgPbPgw/jdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.17.1",
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.7",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming/node_modules/@mui/types": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.10.tgz",
+      "integrity": "sha512-0+4mSjknSu218GW3isRqoxKRTOrTLd/vHi/7UC4+wZcUrOAqD9kRk7UQRL1mcrzqRoe7s3UT6rsRpbLkW5mHpQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming/node_modules/@mui/utils": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.7.tgz",
+      "integrity": "sha512-+YjnjMRnyeTkWnspzoxRdiSOgkrcpTikhNPoxOZW0APXx+urHtUoXJ9lbtCZRCA5a4dg5gSbd19alL1DvRs5fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@mui/types": "^7.4.10",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3899,19 +3942,21 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
-      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.7.tgz",
+      "integrity": "sha512-y/QkNXv6cF6dZ5APztd/dFWfQ6LHKPx3skyYO38YhQD4+Cxd6sFAL3Z38WMSSC8LQz145Mpp3CcLrSCLKPwYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.13.5",
+        "@babel/runtime": "^7.28.4",
+        "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
-        "csstype": "^3.1.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3932,22 +3977,23 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
-      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.7.tgz",
+      "integrity": "sha512-DovL3k+FBRKnhmatzUMyO5bKkhMLlQ9L7Qw5qHrre3m8zCZmE+31NDVBFfqrbrA7sq681qaEIHdkWD5nmiAjyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
+        "@babel/runtime": "^7.28.4",
+        "@mui/private-theming": "^7.3.7",
+        "@mui/styled-engine": "^7.3.7",
+        "@mui/types": "^7.4.10",
+        "@mui/utils": "^7.3.7",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3971,6 +4017,55 @@
         }
       }
     },
+    "node_modules/@mui/system/node_modules/@mui/types": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.10.tgz",
+      "integrity": "sha512-0+4mSjknSu218GW3isRqoxKRTOrTLd/vHi/7UC4+wZcUrOAqD9kRk7UQRL1mcrzqRoe7s3UT6rsRpbLkW5mHpQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system/node_modules/@mui/utils": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.7.tgz",
+      "integrity": "sha512-+YjnjMRnyeTkWnspzoxRdiSOgkrcpTikhNPoxOZW0APXx+urHtUoXJ9lbtCZRCA5a4dg5gSbd19alL1DvRs5fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@mui/types": "^7.4.10",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/types": {
       "version": "7.2.24",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
@@ -3986,20 +4081,20 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
-      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "~7.2.15",
-        "@types/prop-types": "^15.7.12",
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "~7.2.24",
+        "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
         "react-is": "^19.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4013,6 +4108,92 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.29.4.tgz",
+      "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-internals": "7.29.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -4606,9 +4787,9 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.1.tgz",
-      "integrity": "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -6648,9 +6829,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001765",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
+      "integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7663,19 +7844,13 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
-    "@mui/icons-material": "^5.2.1",
+    "@mui/icons-material": "^6.3.0",
     "@mui/lab": "^5.0.0-alpha.59",
     "@mui/material": "^6.3.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.6.0",
+    "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^6.3.0",
     "@mui/lab": "^5.0.0-alpha.59",
     "@mui/material": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^6.3.0",
-    "@mui/lab": "^5.0.0-alpha.59",
     "@mui/material": "^6.3.0",
     "@mui/x-date-pickers": "^7.23.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@emotion/react": "^11.7.0",
+    "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^6.3.0",
     "@mui/lab": "^5.0.0-alpha.59",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
-    "date-fns": "^2.27.0",
+    "date-fns": "^4.1.0",
     "firebase": "^9.0.0",
     "framer-motion": "^4.1.3",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.2.1",
     "@mui/lab": "^5.0.0-alpha.59",
-    "@mui/material": "^5.2.3",
+    "@mui/material": "^6.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@mui/icons-material": "^6.3.0",
     "@mui/lab": "^5.0.0-alpha.59",
     "@mui/material": "^6.3.0",
+    "@mui/x-date-pickers": "^7.23.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -210,7 +210,6 @@ const Form = () => {
                     {/* attempts to change color https://github.com/mui-org/material-ui-pickers/issues/393 */}
                     <LocalizationProvider dateAdapter={AdapterDateFns}>
                         <DateTimePicker
-                            renderInput={(props) => <TextField {...props} />}
                             // required={formData.deadlineType !== "noDeadline"}
                             value={formData.dueDate}
                             label="Due Date"
@@ -220,11 +219,15 @@ const Form = () => {
                                     setFormData({...formData, dueDate: e, deadlineType: "hard"});
                                 else
                                     setFormData({...formData, dueDate: e});
-                                
+
                                 setQuickAdd({...quickAdd, formModified: true});
                             }}
-                            className="textfield"
-                            size="medium"
+                            slotProps={{
+                                textField: {
+                                    className: "textfield",
+                                    size: "medium"
+                                }
+                            }}
                         />
                     </LocalizationProvider>
 
@@ -332,15 +335,18 @@ const Form = () => {
 
                 <LocalizationProvider dateAdapter={AdapterDateFns}>
                     <DateTimePicker
-                        renderInput={(props) => <TextField {...props} />}
                         // required={formData.deadlineType !== "noDeadline"}
                         value={formData.endRecurring}
                         label="End Recurring"
                         onChange={(e) => {
                             setFormData({...formData, endRecurring: e});
                         }}
-                        className="textfield"
-                        size="medium"
+                        slotProps={{
+                            textField: {
+                                className: "textfield",
+                                size: "medium"
+                            }
+                        }}
                     />
                     </LocalizationProvider>
                 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,9 +9,9 @@ import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 // import { AddCircleRoundedIcon, AddCircleOutlineOutlinedIcon } from "@mui/icons-material"
 // import AddCircleOutlineOutlinedIcon from "@material-ui/icons/AddCircleOutlineOutlined";
 
-import AdapterDateFns from "@mui/lab/AdapterDateFns";
-import LocalizationProvider from "@mui/lab/LocalizationProvider";
-import DateTimePicker from "@mui/lab/DateTimePicker";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { addDoc, collection } from "firebase/firestore";
 import { parseDate, parseTime } from "../utils/todosFunctions";
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,7 +9,7 @@ import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 // import { AddCircleRoundedIcon, AddCircleOutlineOutlinedIcon } from "@mui/icons-material"
 // import AddCircleOutlineOutlinedIcon from "@material-ui/icons/AddCircleOutlineOutlined";
 
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { addDoc, collection } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- Updates @mui/material to v6.3.0
- Updates @mui/icons-material to v6.3.0
- Updates @emotion/react to v11.14.0
- Updates @emotion/styled to v11.14.1
- Adds @mui/x-date-pickers v7.23.2
- Updates date-fns to v4.1.0
- Removes @mui/lab (replaced by @mui/x-date-pickers)
- Migrates DateTimePicker imports to @mui/x-date-pickers
- Updates DateTimePicker props for MUI v6 API
- Fixes date-fns v4 adapter (uses AdapterDateFnsV3)

## Changes

### Dependencies
All Material UI packages updated to v6, with @mui/lab removed and replaced by @mui/x-date-pickers.

### Code Changes
**DateTimePicker imports updated:**
```javascript
// Before
import AdapterDateFns from "@mui/lab/AdapterDateFns";
import LocalizationProvider from "@mui/lab/LocalizationProvider";
import DateTimePicker from "@mui/lab/DateTimePicker";

// After
import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
```

> **Note:** The adapter imports from `AdapterDateFnsV3`, not `AdapterDateFns`. The latter uses default imports from deep paths (`import addDays from 'date-fns/addDays'`) which date-fns v4 no longer exports, causing a build failure.

**DateTimePicker props updated (2 instances):**
- Removed deprecated `renderInput` prop
- Moved `className` and `size` to `slotProps.textField`

## Commits
- chore(deps): update @mui/material to v6.3.0
- chore(deps): update @mui/icons-material to v6.3.0
- chore(deps): update @emotion/react to v11.14.0
- chore(deps): update @emotion/styled to v11.14.1
- chore(deps): add @mui/x-date-pickers v7.23.2
- chore(deps): update date-fns to v4.1.0
- chore(deps): remove @mui/lab (replaced by @mui/x-date-pickers)
- refactor(form): migrate DateTimePicker imports to @mui/x-date-pickers
- refactor(form): update DateTimePicker props for MUI v6 API
- chore(deps): update package-lock.json after MUI v6 installation
- fix(form): use AdapterDateFnsV3 for date-fns v4 compatibility

## Testing
Manual testing required:
- Open form and click "Due Date" picker
- Verify calendar modal opens
- Select a date and time
- Verify date displays correctly in field
- Test "End Recurring" picker (enable "Recurring weekly" checkbox first)
- Verify both pickers work without console errors/warnings
- Create a todo with date
- Verify todo saves with correct date format

## Dependencies
- Depends on PR #14 (React 18 Strict Mode fixes)

## Next Steps
After merging, the next PR will remove unused dependencies and update utilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)