### PR TITLE
fix(gapi): handle init and teardown for Strict Mode re-mounts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,11 +42,16 @@ function App() {
     loadGoogleScript(async () => {
       if (!cancelled) {
         setGapiState(prev => ({...prev, gapiLoaded: true}));
-        listener = await handleClientLoad((isSignedIn) => {
+        const result = await handleClientLoad((isSignedIn) => {
           if (!cancelled) {
             setGapiState(prev => ({...prev, gapiLoaded: true, gapiSignedIn: isSignedIn}));
           }
         });
+        if (cancelled) {
+          result?.remove();
+        } else {
+          listener = result;
+        }
       }
     });
 

--- a/src/App.js
+++ b/src/App.js
@@ -37,11 +37,12 @@ function App() {
   useEffect(() => {
     console.log("gapi useEffect");
     let cancelled = false;
+    let listener = null;
 
-    loadGoogleScript(() => {
+    loadGoogleScript(async () => {
       if (!cancelled) {
         setGapiState(prev => ({...prev, gapiLoaded: true}));
-        handleClientLoad((isSignedIn) => {
+        listener = await handleClientLoad((isSignedIn) => {
           if (!cancelled) {
             setGapiState(prev => ({...prev, gapiLoaded: true, gapiSignedIn: isSignedIn}));
           }
@@ -49,7 +50,10 @@ function App() {
       }
     });
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (listener) listener.remove();
+    };
   }, []); 
 
   // effect for firebase login state changes

--- a/src/utils/gapiFunctions.js
+++ b/src/utils/gapiFunctions.js
@@ -10,7 +10,14 @@ export function loadGoogleScript(onLoadFunc){
 
   const firstJs = document.getElementsByTagName("script")[0]; // because react
 
-  if(document.getElementById(id)) return;
+  if(document.getElementById(id)) {
+    if (window.gapi && onLoadFunc) {
+      onLoadFunc();
+    } else if (onLoadFunc) {
+      document.getElementById(id).addEventListener('load', onLoadFunc);
+    }
+    return;
+  }
   if(!firstJs) return; // handle test environment where no scripts exist
 
   const js = document.createElement("script");

--- a/src/utils/gapiFunctions.js
+++ b/src/utils/gapiFunctions.js
@@ -64,7 +64,7 @@ export function handleClientLoad(updateSigninCallback){
         const listener = window.gapi.auth2.getAuthInstance().isSignedIn.listen(updateSigninCallback);
 
         // Handle the initial sign-in state.
-        updateSigninCallback(window.window.gapi.auth2.getAuthInstance().isSignedIn.get());
+        updateSigninCallback(window.gapi.auth2.getAuthInstance().isSignedIn.get());
 
         resolve(listener);
       }, function(error) {

--- a/src/utils/gapiFunctions.js
+++ b/src/utils/gapiFunctions.js
@@ -48,30 +48,29 @@ const SCOPES = "https://www.googleapis.com/auth/calendar.readonly";
  *  listeners.
  */
 export function handleClientLoad(updateSigninCallback){
-  if(window.gapi === undefined) return;
-  
+  if(window.gapi === undefined) return Promise.resolve(null);
+
   console.log("client load yay");
 
-  window.gapi.load("client:auth2", () => {
-    window.gapi.client.init({
-      apiKey: API_KEY,
-      clientId: CLIENT_ID,
-      discoveryDocs: DISCOVERY_DOCS,
-      scope: SCOPES
-    }).then(function () {
-      // Listen for sign-in state changes.
-      window.gapi.auth2.getAuthInstance().isSignedIn.listen(updateSigninCallback);
-      
-      // apparently this also works and doesn't disrupt the former isSignedIn listener
-      // window.gapi.auth2.getAuthInstance().isSignedIn.listen((abool) => console.log("handleLoad, isSignedIn", abool));
-      
-      // window.gapi.auth2.getAuthInstance().isSignedIn.listen(
-      
-      // Handle the initial sign-in state.
-      updateSigninCallback(window.window.gapi.auth2.getAuthInstance().isSignedIn.get());
-      // console.log("handle client load seemed to have worked")
-    }, function(error) {
-      console.log(JSON.stringify(error, null, 2));
+  return new Promise((resolve) => {
+    window.gapi.load("client:auth2", () => {
+      window.gapi.client.init({
+        apiKey: API_KEY,
+        clientId: CLIENT_ID,
+        discoveryDocs: DISCOVERY_DOCS,
+        scope: SCOPES
+      }).then(function () {
+        // Listen for sign-in state changes.
+        const listener = window.gapi.auth2.getAuthInstance().isSignedIn.listen(updateSigninCallback);
+
+        // Handle the initial sign-in state.
+        updateSigninCallback(window.window.gapi.auth2.getAuthInstance().isSignedIn.get());
+
+        resolve(listener);
+      }, function(error) {
+        console.log(JSON.stringify(error, null, 2));
+        resolve(null);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- `loadGoogleScript` now fires the callback on re-mount when the script tag already exists (either immediately if gapi is loaded, or via a load event listener)
- `handleClientLoad` returns a Promise resolving with the gapi `isSignedIn` listener handle, enabling proper cleanup
- App.js gapi useEffect calls `listener.remove()` on cleanup to prevent leaked listeners

## Test plan
- [ ] Verify gapi auth sign-in/sign-out works normally
- [ ] Confirm no duplicate listeners fire after Strict Mode double-mount (check console logs)
- [ ] Test that calendar data loads on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)