### PR TITLE
fix(sort): prevent crash when sorting todos with empty dueDate

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -39,11 +39,15 @@ const Form = () => {
     function addOneTodoToFirebase(todo){
         if(todo.dueDate !== null){ // || todo.dueDate !== "" || (todo.dueDate instanceof Date && isNaN(todo.dueDate))){
             // todo.dueDate = todo.dueDate.toLocaleString()
-            const datObjDueDate = todo.dueDate;
-            todo.dueDate = datObjDueDate.toLocaleDateString().split("/");
-            todo.dueDate = `${todo.dueDate[0]}/${todo.dueDate[1]}/${todo.dueDate[2].substring(2)} `;
-            todo.dueDate += datObjDueDate.toLocaleTimeString().split(" ")[0].split(":", 2).join(":");
-            todo.dueDate += datObjDueDate.toLocaleTimeString().split(" ")[1];
+            const d = todo.dueDate;
+            const month = d.getMonth() + 1;
+            const day = d.getDate();
+            const year = d.getFullYear() % 100;
+            const hours = d.getHours();
+            const minutes = d.getMinutes();
+            const ampm = hours < 12 ? "AM" : "PM";
+            const displayHours = hours % 12 || 12;
+            todo.dueDate = `${month}/${day}/${year < 10 ? "0" + year : year} ${displayHours}:${minutes < 10 ? "0" + minutes : minutes}${ampm}`;
         }
         
         const todoFilePath = "users/" + (auth.currentUser ? auth.currentUser.uid : null) + "/Todos";

--- a/src/utils/todosFunctions.js
+++ b/src/utils/todosFunctions.js
@@ -287,8 +287,9 @@ export function compareForMultipleProperties(...sortOrder){
               ret = 1;  // this means item1 - item2 is positive
           }else if(item2 === ""){
               ret = -1; // this means item1 - item2 is negative
+          }else{
+              ret = todosDateTimeParse(item1) - todosDateTimeParse(item2);
           }
-          ret = todosDateTimeParse(item1) - todosDateTimeParse(item2);
 
           return (ascending ? ret : -1*ret);
       }else if(type === "priority"){

--- a/src/utils/todosFunctions.js
+++ b/src/utils/todosFunctions.js
@@ -281,11 +281,11 @@ export function compareForMultipleProperties(...sortOrder){
       if(type === "dueDate"){
           let ret;
 
-          if(item1 === "" && item2 === ""){
+          if(item1 === null && item2 === null){
               ret = 0;
-          }else if(item1 === ""){
+          }else if(item1 === null){
               ret = 1;  // this means item1 - item2 is positive
-          }else if(item2 === ""){
+          }else if(item2 === null){
               ret = -1; // this means item1 - item2 is negative
           }else{
               ret = todosDateTimeParse(item1) - todosDateTimeParse(item2);

--- a/src/utils/todosFunctions.js
+++ b/src/utils/todosFunctions.js
@@ -4,6 +4,9 @@ export function todosDateTimeParse(todoDateTimeStr){
   }
   const todosRegExp = /([01]{0,1}\d)\/([0123]{0,1}\d)\/(\d\d) ([01]{0,1}\d):([0-5]\d)([AP]M)/i;
   const res = todosRegExp.exec(todoDateTimeStr);
+  if(res === null){
+    return null;
+  }
   const month = parseInt(res[1]) - 1;
   const day = parseInt(res[2]);
   // eslint-disable-next-line no-magic-numbers

--- a/src/utils/todosFunctions.js
+++ b/src/utils/todosFunctions.js
@@ -284,11 +284,14 @@ export function compareForMultipleProperties(...sortOrder){
       if(type === "dueDate"){
           let ret;
 
-          if(item1 === null && item2 === null){
+          const noDate1 = item1 == null || item1 === "";
+          const noDate2 = item2 == null || item2 === "";
+
+          if(noDate1 && noDate2){
               ret = 0;
-          }else if(item1 === null){
+          }else if(noDate1){
               ret = 1;  // this means item1 - item2 is positive
-          }else if(item2 === null){
+          }else if(noDate2){
               ret = -1; // this means item1 - item2 is negative
           }else{
               ret = todosDateTimeParse(item1) - todosDateTimeParse(item2);


### PR DESCRIPTION
## Summary
- Fix crash when sorting todos without a dueDate (`Cannot read properties of null`)
- `singlePropertyCompare` now handles `null`, `undefined`, and `""` dueDate values instead of falling through to `todosDateTimeParse`
- Replace locale-dependent `toLocaleDateString`/`toLocaleTimeString` formatting in `Form.jsx` with direct Date methods so the dueDate string is consistent regardless of system locale (fixes `"14:56undefined"` on 24h locales)
- Add defensive null guard in `todosDateTimeParse` for existing malformed DB entries

## Test plan
- [ ] Create a todo without a dueDate, confirm the list sorts without crashing
- [ ] Create todos with and without dueDates, confirm sort order is correct (empty dates sort last)
- [ ] Create a todo with a dueDate on a 24h locale system, confirm it stores correctly as `M/D/YY H:MMAM/PM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)