### PR TITLE
fix(eventbus): store listener references to enable proper cleanup

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -14,7 +14,7 @@ function Sidebar(){
     }
     
     useEffect(() => {
-        eventBus.on("todoListUpdated", (todoList) => {
+        const handleTodoListUpdated = (todoList) => {
             debugger;
 
             const initialFolderMap = new Map();
@@ -37,11 +37,13 @@ function Sidebar(){
             }
 
             setSidebarElems(sortedFolderMap);
-            
-        });
+
+        };
+
+        eventBus.on("todoListUpdated", handleTodoListUpdated);
 
         // clean up
-        return () => eventBus.remove("todoListUpdated");
+        return () => eventBus.remove("todoListUpdated", handleTodoListUpdated);
     }, []);
     
     

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -158,6 +158,7 @@ class TodoList extends React.Component{
     }
 
     componentWillUnmount() {
+        this.unsubscribeFirebaseTodolist();
         eventBus.remove("filterFolder", this.handleFilterFolder);
         eventBus.remove("filterList", this.handleFilterList);
     }    

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -101,28 +101,23 @@ class TodoList extends React.Component{
 
     componentDidMount(){
         console.log("Todolist mount", this.props, this.state);
-        
+
         if(this.props.firebaseSignedIn !== null){
             this.initializeTodolist();
         }else{
             console.log("Firebase login is null");
         }
 
-        eventBus.on("filterFolder", (data) =>{
-            // this.initializeTodolist(data);
-
+        this.handleFilterFolder = (data) =>{
             this.setState({filter: data});
+        };
 
-            // this.setState({displayedTodoList: this.todoList.filter((elem) => elem.folder === data.folder)});
-        });
-
-        eventBus.on("filterList", (data) =>{
-            // this.initializeTodolist(data);
-
+        this.handleFilterList = (data) =>{
             this.setState({filter: data});
+        };
 
-            // this.setState({displayedTodoList: this.todoList.filter((elem) => (elem.folder === data.folder && elem.list === data.list))});
-        });
+        eventBus.on("filterFolder", this.handleFilterFolder);
+        eventBus.on("filterList", this.handleFilterList);
     }
 
     componentDidUpdate(prevProps, prevState, snapshot){
@@ -163,8 +158,8 @@ class TodoList extends React.Component{
     }
 
     componentWillUnmount() {
-        eventBus.remove("filterFolder");
-        eventBus.remove("filterList");
+        eventBus.remove("filterFolder", this.handleFilterFolder);
+        eventBus.remove("filterList", this.handleFilterList);
     }    
 
     initializeTodolist(filter={}){

--- a/src/utils/eventBus.js
+++ b/src/utils/eventBus.js
@@ -1,14 +1,37 @@
 // thank you internet: https://www.pluralsight.com/guides/how-to-communicate-between-independent-components-in-reactjs
+
+// Maps (event, callback) → wrapper so removeEventListener receives the
+// same function reference that addEventListener registered.
+const listenerMap = new Map();
+
+function getKey(event, callback) {
+    // Each (event, callback) pair gets its own Map entry.
+    // We use a nested Map: event → Map<callback, wrapper>.
+    if (!listenerMap.has(event)) {
+        listenerMap.set(event, new Map());
+    }
+    return listenerMap.get(event);
+}
+
 export const eventBus = {
     on(event, callback){
-        // add event listener
-        document.addEventListener(event, (e) => callback(e.detail));
+        const wrapper = (e) => callback(e.detail);
+        const callbackMap = getKey(event, callback);
+        callbackMap.set(callback, wrapper);
+        document.addEventListener(event, wrapper);
     },
     dispatch(event, data){
         // fires an event
         document.dispatchEvent(new CustomEvent(event, {detail: data}));
     },
     remove(event, callback){
-        document.removeEventListener(event, callback);
+        const callbackMap = listenerMap.get(event);
+        if (callbackMap) {
+            const wrapper = callbackMap.get(callback);
+            if (wrapper) {
+                document.removeEventListener(event, wrapper);
+                callbackMap.delete(callback);
+            }
+        }
     }
 };

--- a/src/utils/eventBus.js
+++ b/src/utils/eventBus.js
@@ -1,37 +1,25 @@
 // thank you internet: https://www.pluralsight.com/guides/how-to-communicate-between-independent-components-in-reactjs
 
-// Maps (event, callback) → wrapper so removeEventListener receives the
-// same function reference that addEventListener registered.
-const listenerMap = new Map();
-
-function getKey(event, callback) {
-    // Each (event, callback) pair gets its own Map entry.
-    // We use a nested Map: event → Map<callback, wrapper>.
-    if (!listenerMap.has(event)) {
-        listenerMap.set(event, new Map());
-    }
-    return listenerMap.get(event);
-}
+// event → Map<callback, wrapper>
+// Keeps track of wrappers so removeEventListener receives the same
+// function reference that addEventListener registered.
+const listeners = new Map();
 
 export const eventBus = {
-    on(event, callback){
+    on(event, callback) {
         const wrapper = (e) => callback(e.detail);
-        const callbackMap = getKey(event, callback);
-        callbackMap.set(callback, wrapper);
+        if (!listeners.has(event)) listeners.set(event, new Map());
+        listeners.get(event).set(callback, wrapper);
         document.addEventListener(event, wrapper);
     },
-    dispatch(event, data){
-        // fires an event
-        document.dispatchEvent(new CustomEvent(event, {detail: data}));
+    dispatch(event, data) {
+        document.dispatchEvent(new CustomEvent(event, { detail: data }));
     },
-    remove(event, callback){
-        const callbackMap = listenerMap.get(event);
-        if (callbackMap) {
-            const wrapper = callbackMap.get(callback);
-            if (wrapper) {
-                document.removeEventListener(event, wrapper);
-                callbackMap.delete(callback);
-            }
+    remove(event, callback) {
+        const wrapper = listeners.get(event)?.get(callback);
+        if (wrapper) {
+            document.removeEventListener(event, wrapper);
+            listeners.get(event).delete(callback);
         }
     }
 };


### PR DESCRIPTION
## Summary
- Fix memory leak in `eventBus.js`: `remove()` was not removing listeners because the wrapper function reference was lost
- Add a `listenerMap` (nested Map) to track (event, callback) → wrapper mappings
- Update Sidebar.js and TodoList.js to pass stable callback references for cleanup
- Unsubscribe Firestore `onSnapshot` listener in TodoList's `componentWillUnmount` to prevent listener leak

## Test plan
- [ ] `npm start` — app loads, sidebar folder filtering works
- [ ] Mount/unmount components — no listener accumulation in DevTools
- [ ] Sign into Firebase, confirm todos load, navigate away — no Firestore listener activity after unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)